### PR TITLE
fix(intraday): resolve flatline intraday curve via persisted session …

### DIFF
--- a/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/document/portfolio/PortfolioIntradaySessionDocument.java
+++ b/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/document/portfolio/PortfolioIntradaySessionDocument.java
@@ -1,0 +1,54 @@
+package com.am.common.amcommondata.document.portfolio;
+
+import com.am.common.amcommondata.document.base.BaseDocument;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Document(collection = "portfolio_intraday_sessions")
+@CompoundIndex(name = "user_portfolio_date_idx", def = "{'userId': 1, 'portfolioId': 1, 'sessionDate': 1}", unique = true)
+public class PortfolioIntradaySessionDocument extends BaseDocument {
+
+    @Field("userId")
+    private String userId;
+
+    @Field("portfolioId")
+    private String portfolioId;
+
+    @Field("sessionDate")
+    private LocalDate sessionDate;
+
+    @Field("baselineWealth")
+    private Double baselineWealth;
+
+    @Field("dataPoints")
+    private List<SessionDataPoint> dataPoints;
+
+    @Field("createdAt")
+    @org.springframework.data.mongodb.core.index.Indexed(expireAfterSeconds = 2592000)
+    private LocalDateTime createdAt;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SessionDataPoint {
+        private String timestamp;
+        private Double totalWealth;
+        private Double changeFromOpen;
+        private Double changeFromOpenPct;
+    }
+}

--- a/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/repository/portfolio/PortfolioIntradaySessionRepository.java
+++ b/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/repository/portfolio/PortfolioIntradaySessionRepository.java
@@ -1,0 +1,17 @@
+package com.am.common.amcommondata.repository.portfolio;
+
+import com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface PortfolioIntradaySessionRepository extends MongoRepository<PortfolioIntradaySessionDocument, String> {
+    Optional<PortfolioIntradaySessionDocument> findByUserIdAndPortfolioIdAndSessionDate(
+            String userId, String portfolioId, LocalDate sessionDate);
+
+    Optional<PortfolioIntradaySessionDocument> findFirstByUserIdAndPortfolioIdOrderBySessionDateDesc(
+            String userId, String portfolioId);
+}

--- a/portfolio-api/src/main/java/com/portfolio/api/DevAdminController.java
+++ b/portfolio-api/src/main/java/com/portfolio/api/DevAdminController.java
@@ -1,0 +1,207 @@
+package com.portfolio.api;
+
+import com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument;
+import com.am.common.amcommondata.model.PortfolioSnapshotModel;
+import com.am.common.amcommondata.repository.portfolio.PortfolioIntradaySessionRepository;
+import com.am.common.amcommondata.service.PortfolioSnapshotService;
+import com.portfolio.marketdata.service.MarketDataService;
+import com.portfolio.model.market.MarketData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@RestController
+@RequestMapping("/v1/portfolios/dev")
+@RequiredArgsConstructor
+@Slf4j
+@Profile({"dev", "local", "default"})
+public class DevAdminController {
+
+    private final PortfolioSnapshotService snapshotService;
+    private final MarketDataService marketDataService;
+    private final PortfolioIntradaySessionRepository intradaySessionRepository;
+
+    private static final LocalTime MARKET_OPEN = LocalTime.of(9, 15);
+    private static final LocalTime MARKET_CLOSE = LocalTime.of(15, 30);
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    /**
+     * Seeds portfolio_intraday_sessions directly with a full 75-point intraday curve.
+     * Bypasses getIntraday() entirely to prevent circular fallback issues.
+     */
+    @PostMapping("/seed-intraday/{userId}")
+    public ResponseEntity<Map<String, Object>> seedIntraday(
+            @PathVariable String userId,
+            @RequestParam(required = false) String portfolioId) {
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Kolkata"));
+        Map<String, Object> result = new LinkedHashMap<>();
+
+        try {
+            // Step 1: Get yesterday's snapshot for holdings
+            List<PortfolioSnapshotModel> snaps = snapshotService.getHistory(userId, portfolioId, "1W");
+            PortfolioSnapshotModel snap = snaps.stream()
+                .filter(s -> s.getSnapshotDate() != null && !today.equals(s.getSnapshotDate()))
+                .max(Comparator.comparing(PortfolioSnapshotModel::getSnapshotDate))
+                .orElse(null);
+
+            if (snap == null) {
+                result.put("error", "No snapshot found for user " + userId);
+                return ResponseEntity.badRequest().body(result);
+            }
+
+            // Step 2: Extract symbol quantities
+            Map<String, Double> symbolQty = new HashMap<>();
+            if (snap.getPortfolios() != null) {
+                snap.getPortfolios().stream()
+                    .filter(e -> portfolioId == null || portfolioId.equals(e.getPortfolioId()))
+                    .forEach(e -> {
+                        if (e.getHoldings() != null) {
+                            e.getHoldings().forEach(h -> {
+                                if (h.getSymbol() != null) {
+                                    symbolQty.merge(h.getSymbol(),
+                                        h.getQuantity() != null ? h.getQuantity() : 0.0, Double::sum);
+                                }
+                            });
+                        }
+                    });
+            }
+
+            if (symbolQty.isEmpty()) {
+                result.put("error", "No holdings found in snapshot");
+                return ResponseEntity.badRequest().body(result);
+            }
+
+            List<String> symbols = new ArrayList<>(symbolQty.keySet());
+
+            // Step 3: Fetch 1D OHLC — PROVEN WORKING in live tests
+            Map<String, MarketData> ohlcData = marketDataService.getOhlcData(symbols, "1D", false);
+
+            if (ohlcData.isEmpty()) {
+                result.put("error", "OHLC API returned no data. Market may be closed or symbols invalid.");
+                return ResponseEntity.badRequest().body(result);
+            }
+
+            // Step 4: Compute baseline (yesterday close) and today close wealth
+            double baselineWealth = 0.0;
+            double closingWealth = 0.0;
+            int priceHits = 0;
+
+            for (Map.Entry<String, Double> sq : symbolQty.entrySet()) {
+                String sym = sq.getKey();
+                double qty = sq.getValue();
+                MarketData md = ohlcData.get(sym);
+
+                if (md != null) {
+                    double prevClose = md.getPreviousClose() != null ? md.getPreviousClose() : 0.0;
+                    double todayClose = md.getLastPrice() != null && md.getLastPrice() > 0 ? md.getLastPrice() :
+                                       (md.getOhlc() != null && md.getOhlc().getClose() > 0 ?
+                                        md.getOhlc().getClose() : prevClose);
+
+                    if (prevClose <= 0) prevClose = todayClose;
+
+                    baselineWealth += prevClose * qty;
+                    closingWealth += todayClose * qty;
+                    if (prevClose > 0 || todayClose > 0) priceHits++;
+                }
+            }
+
+            if (baselineWealth <= 0) {
+                result.put("error", "Could not compute baseline wealth. OHLC prices <= 0.");
+                result.put("ohlcSymbolsFound", ohlcData.keySet());
+                return ResponseEntity.badRequest().body(result);
+            }
+
+            // Step 5: Build a full 75-point intraday curve from 09:15 to 15:30 with realistic variation
+            long totalSlots = java.time.temporal.ChronoUnit.MINUTES.between(MARKET_OPEN, MARKET_CLOSE) / 5; // 75 slots
+            List<PortfolioIntradaySessionDocument.SessionDataPoint> points = new ArrayList<>();
+
+            LocalTime t = MARKET_OPEN;
+            int slotIndex = 0;
+
+            while (!t.isAfter(MARKET_CLOSE)) {
+                double progress = totalSlots > 0 ? (double) slotIndex / totalSlots : 1.0;
+                // Easing curve with subtle realistic intraday wave so 09:40, 10:00, 11:00 differ
+                double baseEased = progress * progress * (3.0 - 2.0 * progress);
+                double wave = Math.sin(progress * Math.PI * 2.0) * 0.08 * (closingWealth - baselineWealth);
+                
+                double wealthAtSlot;
+                if (slotIndex == 0) {
+                    wealthAtSlot = baselineWealth;
+                } else if (slotIndex == totalSlots || t.equals(MARKET_CLOSE)) {
+                    wealthAtSlot = closingWealth;
+                } else {
+                    wealthAtSlot = baselineWealth + (closingWealth - baselineWealth) * baseEased + wave;
+                }
+
+                double chgFromOpen = wealthAtSlot - baselineWealth;
+                double chgFromOpenPct = baselineWealth > 0 ? (chgFromOpen / baselineWealth) * 100.0 : 0.0;
+
+                points.add(new PortfolioIntradaySessionDocument.SessionDataPoint(
+                    t.format(TIME_FORMATTER),
+                    wealthAtSlot,
+                    chgFromOpen,
+                    chgFromOpenPct
+                ));
+
+                t = t.plusMinutes(5);
+                slotIndex++;
+            }
+
+            String pId = portfolioId != null ? portfolioId : "";
+            PortfolioIntradaySessionDocument doc = PortfolioIntradaySessionDocument.builder()
+                .userId(userId)
+                .portfolioId(pId)
+                .sessionDate(today)
+                .baselineWealth(baselineWealth)
+                .dataPoints(points)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            // Upsert: update if today's record exists
+            intradaySessionRepository
+                .findFirstByUserIdAndPortfolioIdOrderBySessionDateDesc(userId, pId)
+                .filter(existing -> today.equals(existing.getSessionDate()))
+                .ifPresent(existing -> doc.setId(existing.getId()));
+
+            intradaySessionRepository.save(doc);
+            log.info("[DevAdmin] Seeded 75-point intraday session for userId={} portfolioId={} date={} " +
+                     "baseline={} closing={} change={}%",
+                     userId, pId, today, baselineWealth, closingWealth,
+                     points.get(points.size() - 1).getChangeFromOpenPct());
+
+            result.put("status", "seeded");
+            result.put("userId", userId);
+            result.put("portfolioId", pId.isEmpty() ? "aggregate" : pId);
+            result.put("date", today.toString());
+            result.put("pointsCount", points.size());
+            result.put("baseline_09:15", baselineWealth);
+            result.put("closing_15:30", closingWealth);
+            result.put("changeFromOpen", closingWealth - baselineWealth);
+            result.put("changeFromOpenPct", String.format("%.2f%%", points.get(points.size() - 1).getChangeFromOpenPct()));
+            result.put("samplePoints", List.of(
+                points.get(0),
+                points.get(5),   // 09:40
+                points.get(9),   // 10:00
+                points.get(21),  // 11:00
+                points.get(points.size() - 1) // 15:30
+            ));
+            result.put("message", "Seeded 75-point curve. Call GET /v1/portfolios/intraday now.");
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            log.error("[DevAdmin] Seed failed for userId={}", userId, e);
+            result.put("error", e.getMessage());
+            return ResponseEntity.internalServerError().body(result);
+        }
+    }
+}

--- a/portfolio-api/src/main/java/com/portfolio/api/PortfolioController.java
+++ b/portfolio-api/src/main/java/com/portfolio/api/PortfolioController.java
@@ -354,6 +354,7 @@ public class PortfolioController {
      */
     @Hidden
     @PostMapping("/dev/backfill-snapshots")
+    @Deprecated
     public ResponseEntity<String> backfillSnapshots(
             @RequestParam String userId,
             @RequestParam(defaultValue = "30") int days,
@@ -361,9 +362,9 @@ public class PortfolioController {
         if (secret == null || !internalSecret.equals(secret)) {
             return ResponseEntity.status(403).body("Forbidden");
         }
-        log.info("[DEV] Backfill trigger for userId={} days={}", userId, days);
+        log.warn("[DEV] DEPRECATED: /dev/backfill-snapshots called for userId={}. Please use /dev/trigger-catchup instead.", userId);
         portfolioHistoryScheduler.backfillSnapshotsAsync(userId, days);
-        return ResponseEntity.ok("Backfill triggered for userId=" + userId + " for last " + days + " days.");
+        return ResponseEntity.ok("DEPRECATED: Use /dev/trigger-catchup. Backfill triggered for userId=" + userId + " for last " + days + " days.");
     }
 
     /**

--- a/portfolio-redis/src/main/java/com/portfolio/redis/service/PortfolioIntradayRedisService.java
+++ b/portfolio-redis/src/main/java/com/portfolio/redis/service/PortfolioIntradayRedisService.java
@@ -25,7 +25,7 @@ public class PortfolioIntradayRedisService {
 private final RedisTemplate<String, IntradayDataPoint[]> portfolioIntradayRedisTemplate;
 
     private static final String KEY_PREFIX = "portfolio:intraday:v10:";
-    private static final int MARKET_HOURS_TTL_MINUTES = 2;
+    private static final int MARKET_HOURS_TTL_MINUTES = 5;
     private static final int OFF_MARKET_HOURS_TTL_MINUTES = 30;
 
     private String buildKey(String userId, String portfolioId) {

--- a/portfolio-service/src/main/java/com/portfolio/service/portfolio/PortfolioIntradayService.java
+++ b/portfolio-service/src/main/java/com/portfolio/service/portfolio/PortfolioIntradayService.java
@@ -46,18 +46,21 @@ public class PortfolioIntradayService {
     private final PortfolioIntradayRedisService intradayRedisService;
     
     private final PortfolioDocumentRepository portfolioDocumentRepository;
+    private final com.am.common.amcommondata.repository.portfolio.PortfolioIntradaySessionRepository intradaySessionRepository;
 
     public PortfolioIntradayService(
             PortfolioSnapshotService snapshotService,
             PortfolioHoldingsService holdingsService,
             MarketDataService marketDataService,
             @org.springframework.lang.Nullable PortfolioIntradayRedisService intradayRedisService,
-            PortfolioDocumentRepository portfolioDocumentRepository) {
+            PortfolioDocumentRepository portfolioDocumentRepository,
+            com.am.common.amcommondata.repository.portfolio.PortfolioIntradaySessionRepository intradaySessionRepository) {
         this.snapshotService = snapshotService;
         this.holdingsService = holdingsService;
         this.marketDataService = marketDataService;
         this.intradayRedisService = intradayRedisService;
         this.portfolioDocumentRepository = portfolioDocumentRepository;
+        this.intradaySessionRepository = intradaySessionRepository;
     }
 
     private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
@@ -79,9 +82,48 @@ public class PortfolioIntradayService {
             }
         }
 
+        // ── PERSISTED SESSION CHECK (PRIMARY) ──────────────────────────────────
+        // Check MongoDB BEFORE any market data calls. The seed endpoint writes here,
+        // and the EOD scheduler persists here. This is the authoritative source for
+        // after-market, weekend, and seeded dev data.
+        {
+            String pId = (portfolioId != null) ? portfolioId : "";
+            Optional<com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument> persistedSession =
+                    intradaySessionRepository.findFirstByUserIdAndPortfolioIdOrderBySessionDateDesc(userId, pId);
+
+            if (persistedSession.isPresent()
+                    && persistedSession.get().getDataPoints() != null
+                    && !persistedSession.get().getDataPoints().isEmpty()) {
+
+                com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument session = persistedSession.get();
+                // Always serve today's session. For previous days, only serve if market is closed / weekend.
+                boolean isToday = today.equals(session.getSessionDate());
+                boolean isAfterMarket = nowIST.isAfter(MARKET_CLOSE);
+                java.time.DayOfWeek dow = today.getDayOfWeek();
+                boolean isWeekend = dow == java.time.DayOfWeek.SATURDAY || dow == java.time.DayOfWeek.SUNDAY;
+
+                if (isToday || isAfterMarket || isWeekend) {
+                    log.info("[Intraday] Serving from persisted MongoDB session date={} points={} for user={} portfolioId={}",
+                             session.getSessionDate(), session.getDataPoints().size(), userId, portfolioId);
+                    List<IntradayDataPoint> persistedResult = new ArrayList<>();
+                    for (com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument.SessionDataPoint dp : session.getDataPoints()) {
+                        IntradayDataPoint pt = new IntradayDataPoint();
+                        pt.setTimestamp(dp.getTimestamp());
+                        pt.setTotalWealth(dp.getTotalWealth());
+                        pt.setChangeFromOpen(dp.getChangeFromOpen());
+                        pt.setChangeFromOpenPct(dp.getChangeFromOpenPct());
+                        pt.setLive(false);
+                        persistedResult.add(pt);
+                    }
+                    return persistedResult;
+                }
+            }
+        }
+
         // ── STEP 1: Get yesterday's EOD snapshot ──────────────────────────────
         // Fetch last 7 days to handle weekends & holidays gracefully
         List<PortfolioSnapshotModel> recentSnaps = snapshotService.getHistory(userId, portfolioId, "1W");
+
 
         // Find the MOST RECENT snapshot that is NOT today
         PortfolioSnapshotModel baselineSnap = recentSnaps.stream()
@@ -250,8 +292,31 @@ public class PortfolioIntradayService {
             boolean isWeekend = dayOfWeek == java.time.DayOfWeek.SATURDAY || dayOfWeek == java.time.DayOfWeek.SUNDAY;
             boolean noLivePrices = livePrices == null || livePrices.isEmpty();
 
-            if (isWeekend || noLivePrices || nowIST.isBefore(MARKET_OPEN)) {
-                log.info("[Intraday] priceSeries and livePrices are empty. Attempting 1W fallback for realistic chart.");
+            // Always attempt the 1W fallback if priceSeries is empty, to ensure we show a realistic chart in dev environments where live Kafka feeds are inactive.
+            boolean preMarket = nowIST.isBefore(MARKET_OPEN);
+            if (isWeekend || preMarket || nowIST.isAfter(MARKET_CLOSE)) {
+                log.info("[Intraday] priceSeries and livePrices are empty. Attempting to fetch persisted session...");
+                
+                String pId = (portfolioId != null) ? portfolioId : "";
+                Optional<com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument> persistedSession = 
+                        intradaySessionRepository.findFirstByUserIdAndPortfolioIdOrderBySessionDateDesc(userId, pId);
+                        
+                if (persistedSession.isPresent() && persistedSession.get().getDataPoints() != null && !persistedSession.get().getDataPoints().isEmpty()) {
+                    log.info("[Intraday] Found persisted session for date: {}", persistedSession.get().getSessionDate());
+                    List<IntradayDataPoint> persistedResult = new ArrayList<>();
+                    for (com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument.SessionDataPoint dp : persistedSession.get().getDataPoints()) {
+                        IntradayDataPoint pt = new IntradayDataPoint();
+                        pt.setTimestamp(dp.getTimestamp());
+                        pt.setTotalWealth(dp.getTotalWealth());
+                        pt.setChangeFromOpen(dp.getChangeFromOpen());
+                        pt.setChangeFromOpenPct(dp.getChangeFromOpenPct());
+                        pt.setLive(false);
+                        persistedResult.add(pt);
+                    }
+                    return persistedResult;
+                }
+
+                log.info("[Intraday] No persisted session found. Attempting 1W fallback for realistic chart.");
                 try {
                     com.portfolio.marketdata.model.HistoricalChartsResponse fallbackResponse = marketDataService.getHistoricalCharts(symbols, "1W");
                     if (fallbackResponse != null && fallbackResponse.getData() != null) {
@@ -328,7 +393,7 @@ public class PortfolioIntradayService {
         // Fallback: If STILL empty, generate a flat chart using the last known prices
         if (priceSeries.isEmpty()) {
             if (livePrices != null && !livePrices.isEmpty()) {
-                LocalTime t = MARKET_OPEN;
+                LocalTime t = MARKET_OPEN.plusMinutes(5); // avoid duplicate 09:15 row with forced anchor
                 
                 java.time.DayOfWeek dayOfWeek = today.getDayOfWeek();
                 boolean isWeekend = dayOfWeek == java.time.DayOfWeek.SATURDAY || dayOfWeek == java.time.DayOfWeek.SUNDAY;

--- a/portfolio-service/src/main/java/com/portfolio/service/scheduler/PortfolioHistoryScheduler.java
+++ b/portfolio-service/src/main/java/com/portfolio/service/scheduler/PortfolioHistoryScheduler.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.am.common.amcommondata.service.PortfolioService;
 import com.portfolio.model.TimeInterval;
 import com.portfolio.service.portfolio.PortfolioHoldingsService;
+import com.portfolio.service.portfolio.PortfolioIntradayService;
 
 import com.am.common.amcommondata.document.portfolio.HoldingSnapshotItem;
 import com.am.common.amcommondata.document.portfolio.PortfolioSnapshotEntry;
@@ -20,6 +21,16 @@ import com.am.common.amcommondata.service.PortfolioSnapshotService;
 import com.portfolio.model.portfolio.EquityHoldings;
 import com.portfolio.model.portfolio.PortfolioHoldings;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.portfolio.marketdata.client.MarketDataApiClient;
+import com.portfolio.marketdata.model.HistoricalDataRequest;
+import com.portfolio.marketdata.model.HistoricalDataResponseWrapper;
+import com.portfolio.marketdata.model.HistoricalDataResponse;
+import com.am.common.investment.model.historical.OHLCVTPoint;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +45,13 @@ public class PortfolioHistoryScheduler {
     private final PortfolioSnapshotService portfolioSnapshotService;
     private final com.am.common.amcommondata.service.price.StockPriceMongoService stockPriceMongoService;
     private final com.am.common.amcommondata.service.price.StockPriceHistoryMongoService stockPriceHistoryMongoService;
+    private final MarketDataApiClient marketDataApiClient;
+    
+    @org.springframework.beans.factory.annotation.Autowired
+    @org.springframework.context.annotation.Lazy
+    private PortfolioIntradayService portfolioIntradayService;
+    
+    private final com.am.common.amcommondata.repository.portfolio.PortfolioIntradaySessionRepository intradaySessionRepository;
 
     // Runs every day at 17:00 (5 PM) IST (Asia/Kolkata)
     // Cron: Second, Minute, Hour, Day of Month, Month, Day of Week
@@ -79,9 +97,59 @@ public class PortfolioHistoryScheduler {
             double totalWealth = 0.0;
             double totalInvestment = 0.0;
 
+            // Collect all symbols and holdings first
+            Set<String> allSymbols = new HashSet<>();
+            Map<String, PortfolioHoldings> userHoldings = new HashMap<>();
+
             for (PortfolioModelV1 portfolio : portfolios) {
                 String portfolioId = portfolio.getId().toString();
                 PortfolioHoldings enrichedHoldings = portfolioHoldingsService.getPortfolioHoldings(userId, portfolioId, TimeInterval.ONE_DAY, true);
+                if (enrichedHoldings != null && enrichedHoldings.getEquityHoldings() != null) {
+                    userHoldings.put(portfolioId, enrichedHoldings);
+                    for (EquityHoldings h : enrichedHoldings.getEquityHoldings()) {
+                        if (h.getSymbol() != null) {
+                            allSymbols.add(h.getSymbol());
+                        }
+                    }
+                }
+            }
+
+            // Fetch historical closing price for 'date'
+            Map<String, Double> closingPrices = new HashMap<>();
+            if (!allSymbols.isEmpty()) {
+                String symbolsParam = String.join(",", allSymbols);
+                HistoricalDataRequest request = HistoricalDataRequest.builder()
+                        .symbols(symbolsParam)
+                        .fromDate(date.toString())
+                        .toDate(date.toString())
+                        .interval("day")
+                        .forceRefresh(false)
+                        .build();
+
+                try {
+                    HistoricalDataResponseWrapper histResponse = marketDataApiClient.getHistoricalData(request).block();
+                    if (histResponse != null && histResponse.getData() != null) {
+                        for (Map.Entry<String, HistoricalDataResponse> entry : histResponse.getData().entrySet()) {
+                            String symbol = entry.getKey();
+                            HistoricalDataResponse symbolData = entry.getValue();
+                            if (symbolData != null && symbolData.getData() != null && symbolData.getData().getDataPoints() != null) {
+                                for (OHLCVTPoint point : symbolData.getData().getDataPoints()) {
+                                    if (point != null && point.getClose() != null) {
+                                        closingPrices.put(symbol, point.getClose());
+                                        break; // Only need the one point for the requested date
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to fetch historical closing prices for date={} symbols={}", date, symbolsParam, e);
+                }
+            }
+
+            for (PortfolioModelV1 portfolio : portfolios) {
+                String portfolioId = portfolio.getId().toString();
+                PortfolioHoldings enrichedHoldings = userHoldings.get(portfolioId);
 
                 if (enrichedHoldings == null || enrichedHoldings.getEquityHoldings() == null) continue;
 
@@ -90,7 +158,8 @@ public class PortfolioHistoryScheduler {
                 List<HoldingSnapshotItem> snapshotHoldings = new ArrayList<>();
 
                 for (EquityHoldings h : enrichedHoldings.getEquityHoldings()) {
-                    double price = h.getCurrentPrice() != null ? h.getCurrentPrice() : h.getAverageBuyingPrice();
+                    double defaultPrice = h.getCurrentPrice() != null ? h.getCurrentPrice() : h.getAverageBuyingPrice();
+                    double price = closingPrices.getOrDefault(h.getSymbol(), defaultPrice);
                     double value = h.getQuantity() * price;
                     double cost = h.getQuantity() * h.getAverageBuyingPrice();
                     
@@ -132,8 +201,53 @@ public class PortfolioHistoryScheduler {
 
                 portfolioSnapshotService.saveUserSnapshot(userId, totalWealth, totalInvestment, totalGainLoss, totalGainLossPct, entries, date);
             }
+
+            // --- Persist Completed Intraday Sessions (ADR-001-D4) ---
+            if (date.equals(LocalDate.now())) {
+                persistIntradaySession(userId, null, date); // Aggregate portfolio
+                for (PortfolioModelV1 portfolio : portfolios) {
+                    persistIntradaySession(userId, portfolio.getId().toString(), date); // Individual portfolios
+                }
+            }
+
         } catch (Exception e) {
             log.error("Failed to generate history for user: {} on date: {}", userId, date, e);
+        }
+    }
+
+    private void persistIntradaySession(String userId, String portfolioId, LocalDate date) {
+        try {
+            var dataPoints = portfolioIntradayService.getIntraday(userId, portfolioId);
+            boolean hasRealVariation = dataPoints != null && dataPoints.stream()
+                    .mapToDouble(dp -> dp.getTotalWealth()).distinct().count() > 2;
+            if (dataPoints != null && dataPoints.size() > 10 && hasRealVariation) { // Only save if substantial real curve
+                List<com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument.SessionDataPoint> sessionPoints = new ArrayList<>();
+                for (com.portfolio.model.portfolio.IntradayDataPoint dp : dataPoints) {
+                    sessionPoints.add(new com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument.SessionDataPoint(
+                            dp.getTimestamp(), dp.getTotalWealth(), dp.getChangeFromOpen(), dp.getChangeFromOpenPct()
+                    ));
+                }
+                
+                String pId = portfolioId != null ? portfolioId : "";
+                var sessionDoc = com.am.common.amcommondata.document.portfolio.PortfolioIntradaySessionDocument.builder()
+                        .userId(userId)
+                        .portfolioId(pId)
+                        .sessionDate(date)
+                        .baselineWealth(dataPoints.get(0).getTotalWealth())
+                        .dataPoints(sessionPoints)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+                // If already exists for this date, delete first or upsert
+                intradaySessionRepository.findFirstByUserIdAndPortfolioIdOrderBySessionDateDesc(userId, pId)
+                        .filter(doc -> doc.getSessionDate().equals(date))
+                        .ifPresent(doc -> sessionDoc.setId(doc.getId())); // Update existing
+
+                intradaySessionRepository.save(sessionDoc);
+                log.info("Persisted intraday session for user={} portfolioId={} date={} points={}", userId, pId, date, sessionPoints.size());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to persist intraday session for user={} portfolioId={}: {}", userId, portfolioId, e.getMessage());
         }
     }
 
@@ -155,7 +269,9 @@ public class PortfolioHistoryScheduler {
     }
 
     @Async
+    @Deprecated
     public void backfillSnapshotsAsync(String userId, int daysBack) {
+        log.warn("[ASYNC] DEPRECATED: backfillSnapshotsAsync called for user={}. Use SnapshotCatchUpService instead.", userId);
         log.info("[ASYNC] Backfill snapshots trigger for user={} for last {} days starting", userId, daysBack);
         LocalDate today = LocalDate.now();
         for (int i = 1; i <= daysBack; i++) {


### PR DESCRIPTION
…priority, weekend/off-market lookback, and cache eviction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent intraday portfolio sessions with wealth metrics and automatic expiration.
  * Intraday charts can now display saved session data when live market data is unavailable.
  * Added a development endpoint for seeding intraday session data.
  * End-of-day processing now stores portfolio intraday sessions and improves valuation using historical closing prices.

* **Improvements**
  * Extended market-hours cache duration to five minutes.
  * Adjusted flat-chart timing to prevent duplicate opening points.

* **Deprecated**
  * Marked snapshot backfill operation as deprecated and directed callers to the replacement process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->