### PR TITLE
fix(portfolio-service): qualify static looksLikeIsin call on interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/portfolio-service/src/main/java/com/portfolio/service/resolver/MongoTradingSymbolResolver.java
+++ b/portfolio-service/src/main/java/com/portfolio/service/resolver/MongoTradingSymbolResolver.java
@@ -35,7 +35,7 @@ public class MongoTradingSymbolResolver implements TradingSymbolResolver {
 
         // Already a normal ticker — no DB lookup needed.
         if (normalizedSymbol != null && !normalizedSymbol.isBlank()
-                && !looksLikeIsin(normalizedSymbol)) {
+                && !TradingSymbolResolver.looksLikeIsin(normalizedSymbol)) {
             return normalizedSymbol.trim().toUpperCase();
         }
 
@@ -56,7 +56,7 @@ public class MongoTradingSymbolResolver implements TradingSymbolResolver {
         if (isin != null && !isin.isBlank()) {
             return isin.trim().toUpperCase();
         }
-        if (looksLikeIsin(normalizedSymbol)) {
+        if (TradingSymbolResolver.looksLikeIsin(normalizedSymbol)) {
             return normalizedSymbol.trim().toUpperCase();
         }
         return null;


### PR DESCRIPTION
Qualify looksLikeIsin calls with TradingSymbolResolver inside MongoTradingSymbolResolver.java (static interface methods are not inherited). Configure maven-compiler-plugin with Lombok annotation processor path in parent pom.xml to resolve Slf4j annotation compilation issues globally across all modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated project compilation settings to support the configured Java versions and Lombok processing.

* **Bug Fixes**
  * Improved consistency in trading symbol resolution without changing expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->