### PR TITLE
fix: resolve missing SGBD holdings and add equity_symbol schema mappi…

### DIFF
--- a/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/document/asset/equity/EquityDocument.java
+++ b/am-common-data/am-common-data-mongo/src/main/java/com/am/common/amcommondata/document/asset/equity/EquityDocument.java
@@ -17,6 +17,21 @@ public class EquityDocument extends AssetDocument {
     private String isin;
     @Field("equity_symbol")
     private String symbol;
+
+    @Override
+    /**
+     * Overrides the Lombok-generated getter to provide a schema compatibility fallback.
+     * 
+     * Rationale:
+     * - Groww portfolios store the ticker under 'equity_symbol'.
+     * - Upstox portfolios store the ticker under 'symbol'.
+     * 
+     * By overriding getSymbol(), we first try to return 'equity_symbol'. If it is missing/null,
+     * we fall back to the parent class's (AssetDocument) 'symbol' field.
+     */
+    public String getSymbol() {
+        return (this.symbol != null && !this.symbol.isBlank()) ? this.symbol : super.getSymbol();
+    }
     private String companyName;
     private String sector;
     private String industry;

--- a/portfolio-service/src/main/java/com/portfolio/service/calculator/PortfolioCalculator.java
+++ b/portfolio-service/src/main/java/com/portfolio/service/calculator/PortfolioCalculator.java
@@ -192,6 +192,8 @@ public class PortfolioCalculator {
             }
         }
 
+
+
         Double currentPrice = null;
         Double previousClosePrice = null;
 
@@ -373,14 +375,18 @@ public class PortfolioCalculator {
 
     private Map<String, List<EquityHoldings>> groupSector(List<EquityHoldings> holdings) {
         return holdings.stream()
-                .filter(e -> e.getSector() != null)
-                .collect(Collectors.groupingBy(EquityHoldings::getSector));
+                .collect(Collectors.groupingBy(e -> {
+                    String sector = e.getSector();
+                    return (sector != null && !sector.trim().isEmpty()) ? sector : "-";
+                }));
     }
 
     private Map<String, List<EquityHoldings>> groupMarketCap(List<EquityHoldings> holdings) {
         return holdings.stream()
-                .filter(e -> e.getMarketCap() != null)
-                .collect(Collectors.groupingBy(EquityHoldings::getMarketCap));
+                .collect(Collectors.groupingBy(e -> {
+                    String mc = e.getMarketCap();
+                    return (mc != null && !mc.trim().isEmpty()) ? mc : "UNKNOWN";
+                }));
     }
 
     private Double round(Double value) {


### PR DESCRIPTION
…ng fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equity symbol handling by using an available fallback when the primary symbol is blank.
  * Portfolio holdings with missing sector information are now retained and grouped under “-”.
  * Holdings without market-cap data are now retained and categorized as “UNKNOWN”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->